### PR TITLE
Do not capture nil errors

### DIFF
--- a/client_interceptors.go
+++ b/client_interceptors.go
@@ -25,7 +25,7 @@ func UnaryClientInterceptor(opts ...ClientOption) grpc.UnaryClientInterceptor {
 
 		err := invoker(ctx, method, req, reply, cc, callOpts...)
 
-		if o.ReportOn(err) {
+		if err != nil && o.ReportOn(err) {
 			hub.CaptureException(err)
 		}
 
@@ -50,7 +50,7 @@ func StreamClientInterceptor(opts ...ClientOption) grpc.StreamClientInterceptor 
 
 		clientStream, err := streamer(ctx, desc, cc, method, callOpts...)
 
-		if o.ReportOn(err) {
+		if err != nil && o.ReportOn(err) {
 			hub.CaptureException(err)
 		}
 

--- a/server_interceptors.go
+++ b/server_interceptors.go
@@ -46,7 +46,7 @@ func UnaryServerInterceptor(opts ...ServerOption) grpc.UnaryServerInterceptor {
 		defer recoverWithSentry(hub, ctx, o)
 
 		resp, err := handler(ctx, req)
-		if o.ReportOn(err) {
+		if err != nil && o.ReportOn(err) {
 			tags := grpc_tags.Extract(ctx)
 			for k, v := range tags.Values() {
 				hub.Scope().SetTag(k, v.(string))
@@ -83,7 +83,7 @@ func StreamServerInterceptor(opts ...ServerOption) grpc.StreamServerInterceptor 
 		defer recoverWithSentry(hub, ctx, o)
 
 		err := handler(srv, stream)
-		if o.ReportOn(err) {
+		if err != nil && o.ReportOn(err) {
 			tags := grpc_tags.Extract(ctx)
 			for k, v := range tags.Values() {
 				hub.Scope().SetTag(k, v.(string))


### PR DESCRIPTION
First of all, thanks for the project! :)

I've added some nil checks so it doesn't try capture nil errors. My grpc endpoints return nil when there's nothing wrong, so all my valid requests are currently producing usage errors in sentry at the moment haha.

![Screenshot from 2021-03-22 18-57-07](https://user-images.githubusercontent.com/1408278/112043382-832f1200-8b40-11eb-9b68-d0388890b913.png)

Attached is the error currently being reported in sentry when a successful grpc call is done.

I waive all rights to these code changes and agree to the license
