### PR TITLE
Add option to set operation name override.

### DIFF
--- a/client_interceptors.go
+++ b/client_interceptors.go
@@ -24,7 +24,12 @@ func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 			ctx = sentry.SetHubOnContext(ctx, hub)
 		}
 
-		span := sentry.StartSpan(ctx, "grpc.client")
+		operationName := defaultClientOperationName
+		if o.OperationNameOverride != "" {
+			operationName = o.OperationNameOverride
+		}
+
+		span := sentry.StartSpan(ctx, operationName)
 		ctx = span.Context()
 		md, ok := metadata.FromOutgoingContext(ctx)
 		if ok {
@@ -60,7 +65,12 @@ func StreamClientInterceptor(opts ...Option) grpc.StreamClientInterceptor {
 			ctx = sentry.SetHubOnContext(ctx, hub)
 		}
 
-		span := sentry.StartSpan(ctx, "grpc.client")
+		operationName := defaultClientOperationName
+		if o.OperationNameOverride != "" {
+			operationName = o.OperationNameOverride
+		}
+
+		span := sentry.StartSpan(ctx, operationName)
 		ctx = span.Context()
 		md, ok := metadata.FromOutgoingContext(ctx)
 		if ok {

--- a/config.go
+++ b/config.go
@@ -65,3 +65,15 @@ func (r *reportOnOption) Apply(o *options) {
 func WithReportOn(r reporter) Option {
 	return &reportOnOption{ReportOn: r}
 }
+
+type operationNameOverride struct {
+	OperationNameOverride string
+}
+
+func (r *operationNameOverride) Apply(o *options) {
+	o.OperationNameOverride = r.OperationNameOverride
+}
+
+func WithOperationNameOverride(s string) Option {
+	return &operationNameOverride{OperationNameOverride: s}
+}

--- a/options.go
+++ b/options.go
@@ -7,13 +7,18 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var defaultOptions = &options{
-		Repanic: false,
-		WaitForDelivery: false,
-		ReportOn: ReportAlways,
-		Timeout: 1 * time.Second,
-}
+const (
+	defaultServerOperationName = "grpc.server"
+	defaultClientOperationName = "grpc.client"
+)
 
+var defaultOptions = &options{
+	Repanic:               false,
+	WaitForDelivery:       false,
+	ReportOn:              ReportAlways,
+	Timeout:               1 * time.Second,
+	OperationNameOverride: "",
+}
 
 type options struct {
 	// Repanic configures whether Sentry should repanic after recovery.
@@ -26,8 +31,9 @@ type options struct {
 	Timeout time.Duration
 
 	ReportOn func(error) bool
-}
 
+	OperationNameOverride string
+}
 
 func ReportAlways(error) bool {
 	return true

--- a/server_interceptors.go
+++ b/server_interceptors.go
@@ -41,8 +41,13 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 			ctx = sentry.SetHubOnContext(ctx, hub)
 		}
 
+		operationName := defaultServerOperationName
+		if o.OperationNameOverride != "" {
+			operationName = o.OperationNameOverride
+		}
+
 		md, _ := metadata.FromIncomingContext(ctx) // nil check in ContinueFromGrpcMetadata
-		span := sentry.StartSpan(ctx, "grpc.server", ContinueFromGrpcMetadata(md))
+		span := sentry.StartSpan(ctx, operationName, ContinueFromGrpcMetadata(md))
 		ctx = span.Context()
 		defer span.Finish()
 
@@ -79,8 +84,13 @@ func StreamServerInterceptor(opts ...Option) grpc.StreamServerInterceptor {
 			ctx = sentry.SetHubOnContext(ctx, hub)
 		}
 
+		operationName := defaultServerOperationName
+		if o.OperationNameOverride != "" {
+			operationName = o.OperationNameOverride
+		}
+
 		md, _ := metadata.FromIncomingContext(ctx) // nil check in ContinueFromGrpcMetadata
-		span := sentry.StartSpan(ctx, "grpc.server", ContinueFromGrpcMetadata(md))
+		span := sentry.StartSpan(ctx, operationName, ContinueFromGrpcMetadata(md))
 		ctx = span.Context()
 		defer span.Finish()
 


### PR DESCRIPTION
Dear John,

Thank you for your library.

We'd like the option to set the sentry span operation name through the use of an override. I've added an `OperationNameOverride` with corresponding `WithOperationNameOverride` function to the options.

Let me know if you need anything else