### PR TITLE
Add option to disable capturing the request body

### DIFF
--- a/config.go
+++ b/config.go
@@ -77,3 +77,15 @@ func (r *operationNameOverride) Apply(o *options) {
 func WithOperationNameOverride(s string) Option {
 	return &operationNameOverride{OperationNameOverride: s}
 }
+
+type captureRequestBodyOption struct {
+	CaptureRequestBody bool
+}
+
+func (c *captureRequestBodyOption) Apply(o *options) {
+	o.CaptureRequestBody = c.CaptureRequestBody
+}
+
+func WithCaptureRequestBody(b bool) Option {
+	return &captureRequestBodyOption{CaptureRequestBody: b}
+}

--- a/options.go
+++ b/options.go
@@ -18,6 +18,7 @@ var defaultOptions = &options{
 	ReportOn:              ReportAlways,
 	Timeout:               1 * time.Second,
 	OperationNameOverride: "",
+	CaptureRequestBody:    true,
 }
 
 type options struct {
@@ -33,6 +34,9 @@ type options struct {
 	ReportOn func(error) bool
 
 	OperationNameOverride string
+
+	// CaptureRequestBody configures whether the request body should be sent to Sentry.
+	CaptureRequestBody bool
 }
 
 func ReportAlways(error) bool {

--- a/server_interceptors.go
+++ b/server_interceptors.go
@@ -51,8 +51,10 @@ func UnaryServerInterceptor(opts ...Option) grpc.UnaryServerInterceptor {
 		ctx = span.Context()
 		defer span.Finish()
 
-		// TODO: Perhaps makes sense to use SetRequestBody instead?
-		hub.Scope().SetExtra("requestBody", req)
+		if o.CaptureRequestBody {
+			// TODO: Perhaps makes sense to use SetRequestBody instead?
+			hub.Scope().SetExtra("requestBody", req)
+		}
 		defer recoverWithSentry(hub, ctx, o)
 
 		resp, err := handler(ctx, req)


### PR DESCRIPTION
Putting the full request body of a grpc message in the Sentry extras can cause the exception to be rejected by Sentry because the event size is too large. I've added the option `WithCaptureRequestBody` so it is possible to disable that the request body is registered. The default is set to `true`, so this PR is fully backward compatible.