### PR TITLE
Fix parent transaction linking, add more details to transactions and update to newest Sentry SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/johnbellone/grpc-middleware-sentry
 go 1.17
 
 require (
-	github.com/getsentry/sentry-go v0.20.0
+	github.com/getsentry/sentry-go v0.27.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	google.golang.org/grpc v1.56.3
 )

--- a/go.sum
+++ b/go.sum
@@ -689,6 +689,7 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/getsentry/sentry-go v0.20.0 h1:bwXW98iMRIWxn+4FgPW7vMrjmbym6HblXALmhjHmQaQ=
 github.com/getsentry/sentry-go v0.20.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
+github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.8.1/go.mod h1:ji8BvRH1azfM+SYow9zQ6SZMvR8qOMZHmsCuWR9tTTk=


### PR DESCRIPTION
In a project where we use this library the span created by the server interceptor was not correctly linked to the parent span from the client. Also requests with no trace id would not get there spans registered, since Sentry will throw away any spans that do not have a transaction. We were also missing some details about the transaction, like the grpc method that was used.

Here is a list of the changes:
- Use `StartTransaction` instead of `StartSpan`. This will ensure the span to be registered in Sentry.
- Beside the `sentry-trace` header, also add the `baggage` header to grpc requests. This is used for distributed Sentry tracing.
- Update to Sentry SDK `0.27.0`.
- Set the `Sampled` value of a transaction to `true` when an error occurs, so all errors will contain traces.